### PR TITLE
Add Microsoft Azure support

### DIFF
--- a/lib/openai.rb
+++ b/lib/openai.rb
@@ -15,7 +15,7 @@ module OpenAI
 
   class Configuration
     attr_writer :access_token
-    attr_accessor :api_version, :organization_id, :uri_base, :request_timeout
+    attr_accessor :api_type, :api_version, :organization_id, :uri_base, :request_timeout
 
     DEFAULT_API_VERSION = "v1".freeze
     DEFAULT_URI_BASE = "https://api.openai.com/".freeze
@@ -23,6 +23,7 @@ module OpenAI
 
     def initialize
       @access_token = nil
+      @api_type = nil
       @api_version = DEFAULT_API_VERSION
       @organization_id = nil
       @uri_base = DEFAULT_URI_BASE

--- a/lib/openai/http.rb
+++ b/lib/openai/http.rb
@@ -68,14 +68,27 @@ module OpenAI
     end
 
     def uri(path:)
-      OpenAI.configuration.uri_base + OpenAI.configuration.api_version + path
+      if OpenAI.configuration.api_type == :azure
+        OpenAI.configuration.uri_base + path + "?api-version=#{OpenAI.configuration.api_version}"
+      else
+        OpenAI.configuration.uri_base + OpenAI.configuration.api_version + path
+      end
     end
 
     def headers
+      return azure_headers if OpenAI.configuration.api_type == :azure
+
       {
         "Content-Type" => "application/json",
         "Authorization" => "Bearer #{OpenAI.configuration.access_token}",
         "OpenAI-Organization" => OpenAI.configuration.organization_id
+      }
+    end
+
+    def azure_headers
+      {
+        "Content-Type" => "application/json",
+        "api-key" => OpenAI.configuration.access_token
       }
     end
 

--- a/spec/openai/client/http_spec.rb
+++ b/spec/openai/client/http_spec.rb
@@ -184,4 +184,58 @@ RSpec.describe OpenAI::HTTP do
       it { expect(parsed).to eq([{ "prompt" => ":)" }, { "prompt" => ":(" }]) }
     end
   end
+
+  describe ".uri" do
+    let(:path) { "/chat" }
+    let(:uri) { OpenAI::Client.send(:uri, path: path) }
+
+    it { expect(uri).to eq("https://api.openai.com/v1/chat") }
+
+    describe "with Azure" do
+      before do
+        OpenAI.configuration.uri_base = "https://custom-domain.openai.azure.com/openai/deployments/gpt-35-turbo"
+        OpenAI.configuration.api_type = :azure
+      end
+
+      after do
+        OpenAI.configuration.uri_base = "https://api.openai.com/"
+        OpenAI.configuration.api_type = nil
+      end
+
+      let(:path) { "/chat" }
+      let(:uri) { OpenAI::Client.send(:uri, path: path) }
+
+      it { expect(uri).to eq("https://custom-domain.openai.azure.com/openai/deployments/gpt-35-turbo/chat?api-version=v1") }
+    end
+  end
+
+  describe ".headers" do
+    before do
+      OpenAI.configuration.api_type = :nil
+    end
+
+    let(:headers) { OpenAI::Client.send(:headers) }
+
+    it {
+      expect(headers).to eq({ "Authorization" => "Bearer #{OpenAI.configuration.access_token}",
+                              "Content-Type" => "application/json", "OpenAI-Organization" => nil })
+    }
+
+    describe "with Azure" do
+      before do
+        OpenAI.configuration.api_type = :azure
+      end
+
+      after do
+        OpenAI.configuration.api_type = nil
+      end
+
+      let(:headers) { OpenAI::Client.send(:headers) }
+
+      it {
+        expect(headers).to eq({ "Content-Type" => "application/json",
+                                "api-key" => OpenAI.configuration.access_token })
+      }
+    end
+  end
 end


### PR DESCRIPTION
Origin PR: https://github.com/alexrudall/ruby-openai/pull/238

Problem

Resolves https://github.com/alexrudall/ruby-openai/issues/231. We would like to use ruby-openai with Microsoft Azure OpenAI, however its endpoints and authentication headers are slightly different, making it impossible currently to use this gem.

Solution

This PR adds a configuration setting api_type, which can be set to :azure, similar to how https://github.com/openai/openai-python supports Microsoft Azure.

Alternatives

I'm aware of the changes being worked on in https://github.com/alexrudall/ruby-openai/pull/150, it might be possible to create a subclass of OpenAI::Client instead once this has been implemented. I'm happy to rebase and refactor this PR once this is merged.

Additional context

Microsoft Azure currently only supports completions and embeddings, so these are the only endpoints implemented
A Microsoft Azure account is needed to rerecord the tests with VCR, and the account needs to have OpenAI access. Currently a form needs to be submitted for this. Also, a deployment has to be created for every model used in the tests, and the deployment name has to match the model name. Documentation should probably be written for this.